### PR TITLE
Build in resume functionality to not re-download successfully downloaded files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     wasapi_client (0.1.0)
       activesupport
+      digest
       faraday
       faraday-follow_redirects
       faraday-retry
@@ -40,6 +41,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
+    digest (3.2.0)
     docile (1.4.1)
     drb (2.2.3)
     erb (5.0.1)

--- a/lib/wasapi_client.rb
+++ b/lib/wasapi_client.rb
@@ -47,25 +47,27 @@ class WasapiClient
   # @param output_dir [String] the directory to save the WARC files to
   # @param crawl_start_after [String] the start date for the crawl in RFC3339 format
   # @param crawl_start_before [String] the end date for the crawl in RFC3339 format
+  # rubocop:disable Metrics/CyclomaticComplexity
   def fetch_warcs(collection:, output_dir:, crawl_start_after: nil, crawl_start_before: nil)
     locations = get_locations(collection:, crawl_start_after:, crawl_start_before:)
-
     return nil if locations.empty?
 
     FileUtils.mkdir_p(output_dir) unless Dir.exist?(output_dir)
     locations.each do |location|
-      filepath = fetch_file(file: location[:url], output_dir:)
+      # See if the file already exists and has the correct checksum
+      filepath = File.join(output_dir, File.basename(location[:url]))
+      next if checksum_valid?(filepath:, expected_md5: location[:md5])
 
       retries = 0
-
       until (valid = checksum_valid?(filepath:, expected_md5: location[:md5])) || retries >= NUM_RETRIES
-        filepath = fetch_file(file: location[:url], output_dir:)
+        fetch_file(file: location[:url], output_dir:)
         retries += 1
       end
 
       raise "Failed to fetch a valid file for #{location[:url]} after #{NUM_RETRIES} retries" unless valid
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   # Send a GET request for the URLs for WARCs. Response will be paginated.
   # @param collection [String] the Archive-It collection ID to fetch WARC files for
@@ -80,7 +82,7 @@ class WasapiClient
     }
 
     response = query(params:)
-    extract_files(response)
+    extract_files(response:, params:)
   end
 
   # Fetch a specific file from the WASAPI storage location.
@@ -92,15 +94,15 @@ class WasapiClient
     file = URI.join(base_url, file).to_s unless file.start_with?('http')
 
     download(url: file, output_dir:)
-    File.join(output_dir, File.basename(file))
   end
 
   private
 
-  # Extract the WARC file locations from the response while paginating through results
+  # Extract the WARC file locations and checksums from the response while paginating through results
   # @param response [Hash] the parsed JSON response from the WASAPI API
+  # @param params [Hash] the parameters used for the request, to support pagination
   # @return [Array<Hash>] hashes containing WARC file location (URL) and md5 checksum
-  def extract_files(response)
+  def extract_files(response:, params:)
     files = response['files']
     return [] unless files.any?
 
@@ -108,15 +110,14 @@ class WasapiClient
     files.map! { |file| { url: file['locations'].first, md5: file&.dig('checksums', 'md5') } }
 
     while response['next']
-      params['page'] = response['next']
-      response = query(params:)
+      response = query(params:, next_page: response['next'])
       new_files = response['files']
       return [] unless new_files.any?
 
       files << new_files.map! { |file| { url: file['locations'].first, md5: file&.dig('checksums', 'md5') } }
     end
 
-    files
+    files.flatten
   end
 
   # Send a GET request for WARC files matching the query params
@@ -125,9 +126,16 @@ class WasapiClient
   #   - crawl-start-after: the start date for the crawl in RFC3339 format
   #   - crawl-start-before: the end date for the crawl in RFC3339 format
   # @param base_url [String] the base URL for the WASAPI API
+  # @param next_page [String, nil] the URL for the next page of results, if available
   # @return [Hash] parsed JSON response
-  def query(params:, base_url: default_url)
-    response = connection(base_url).get('/wasapi/v1/webdata', params)
+  def query(params:, base_url: default_url, next_page: nil)
+    # If a next page is provided, use it to fetch the next set of results
+    response = if next_page
+                 connection(next_page).get
+               else
+                 connection(base_url).get('/wasapi/v1/webdata', params)
+               end
+
     raise "Failed to get list of WARCS: #{response.status}: #{response.body}" unless response.success?
 
     return nil unless response.body
@@ -154,6 +162,7 @@ class WasapiClient
   # Calculate the MD5 checksum of the downloaded file and verify it against the expected checksum
   def checksum_valid?(filepath:, expected_md5:)
     raise "No md5 checksum provided for #{File.basename(filepath)}" unless expected_md5
+    return false unless File.exist?(filepath)
 
     actual_md5 = Digest::MD5.file(filepath).hexdigest
     actual_md5 == expected_md5

--- a/spec/wasapi_client_spec.rb
+++ b/spec/wasapi_client_spec.rb
@@ -83,21 +83,137 @@ RSpec.describe WasapiClient do
       FileUtils.remove_entry(output_dir)
     end
 
-    it 'downloads WARC files to the specified directory' do
-      expect do
-        client.fetch_warcs(
-          collection: collection_id,
-          crawl_start_after: crawl_start_after,
-          crawl_start_before: crawl_start_before,
-          output_dir: output_dir
-        )
-      end.not_to raise_error
+    context 'when downloading for the first time' do
+      let(:filepath) { File.join(output_dir, 'warc1.warc.gz') }
+      let(:filepath2) { File.join(output_dir, 'warc2.warc.gz') }
 
-      expect(Dir.entries(output_dir).select { |f| f.end_with?('.gz') })
-        .to match_array(['warc1.warc.gz', 'warc2.warc.gz'])
+      before do
+        FileUtils.mkdir_p(output_dir)
+        allow(Digest::MD5).to receive(:file).with(filepath).and_return(instance_double(Digest::MD5,
+                                                                                       hexdigest: md5_mock))
+        allow(Digest::MD5).to receive(:file).with(filepath2).and_return(instance_double(Digest::MD5,
+                                                                                        hexdigest: md5_mock))
+      end
+
+      it 'downloads WARC files to the specified directory' do
+        expect do
+          client.fetch_warcs(
+            collection: collection_id,
+            crawl_start_after: crawl_start_after,
+            crawl_start_before: crawl_start_before,
+            output_dir: output_dir
+          )
+        end.not_to raise_error
+
+        expect(Dir.entries(output_dir).select { |f| f.end_with?('.gz') })
+          .to match_array(['warc1.warc.gz', 'warc2.warc.gz'])
+      end
     end
 
-    context 'when downloaded file does not have valid checksum' do
+    context 'when paginated response is returned' do
+      let(:response_body) do
+        {
+          'count' => 2,
+          'next' => 'https://example.com/wasapi/v1/webdata?page=2',
+          'previous' => nil,
+          'files' => [
+            { 'filename' => 'warc1.warc.gz',
+              'checksums' => { 'md5' => md5_mock },
+              'locations' => ['https://example.com/warc1.warc.gz', 'https://backup.example.com/warc1.warc.gz'],
+              'crawl-time' => '2017-03-07T20:01:32Z',
+              'crawl-start' => '2017-03-07T20:01:18Z',
+              'store-time' => '2017-03-08T23:25:41Z' }
+          ]
+        }
+      end
+      let(:response_body_page2) do
+        {
+          'count' => 2,
+          'next' => nil,
+          'previous' => 'https://example.com/wasapi/v1/webdata?page=1',
+          'files' => [
+            { 'filename' => 'warc2.warc.gz',
+              'checksums' => { 'md5' => md5_mock },
+              'locations' => ['https://example.com/warc2.warc.gz', 'https://backup.example.com/warc2.warc.gz'],
+              'crawl-time' => '2017-03-07T20:01:32Z',
+              'crawl-start' => '2017-03-07T20:01:18Z',
+              'store-time' => '2017-03-08T23:25:41Z' }
+          ]
+        }
+      end
+
+      before do
+        stub_request(:get, "#{client.default_url}/wasapi/v1/webdata")
+          .with(query: {
+                  'collection': collection_id,
+                  'crawl-start-after': crawl_start_after,
+                  'crawl-start-before': crawl_start_before
+                })
+          .to_return(status: 200, body: response_body.to_json, headers: { 'Content-Type' => 'application/json' })
+        stub_request(:get, 'https://example.com/wasapi/v1/webdata?page=2')
+          .to_return(status: 200, body: response_body_page2.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'fetches all WARC files across paginated responses' do
+        expect do
+          client.fetch_warcs(
+            collection: collection_id,
+            crawl_start_after: crawl_start_after,
+            crawl_start_before: crawl_start_before,
+            output_dir: output_dir
+          )
+        end.not_to raise_error
+
+        expect(Dir.entries(output_dir).select { |f| f.end_with?('.gz') })
+          .to match_array(['warc1.warc.gz', 'warc2.warc.gz'])
+      end
+    end
+
+    context 'when full file already exists' do
+      let(:response_body) do
+        {
+          'count' => 2,
+          'next' => nil,
+          'previous' => nil,
+          'files' => [
+            { 'filename' => 'warc1.warc.gz',
+              'checksums' => { 'md5' => md5_mock },
+              'locations' => ['https://example.com/warc1.warc.gz', 'https://backup.example.com/warc1.warc.gz'],
+              'crawl-time' => '2017-03-07T20:01:32Z',
+              'crawl-start' => '2017-03-07T20:01:18Z',
+              'store-time' => '2017-03-08T23:25:41Z' }
+          ]
+        }
+      end
+
+      before do
+        FileUtils.mkdir_p(output_dir)
+        File.write(File.join(output_dir, 'warc1.warc.gz'), 'existing content for warc1.warc.gz')
+        stub_request(:get, "#{client.default_url}/wasapi/v1/webdata")
+          .with(query: {
+                  'collection': collection_id,
+                  'crawl-start-after': crawl_start_after,
+                  'crawl-start-before': crawl_start_before
+                })
+          .to_return(status: 200, body: response_body.to_json, headers: { 'Content-Type' => 'application/json' })
+        allow(Digest::MD5).to receive(:file).and_return(instance_double(Digest::MD5, hexdigest: 'md5'))
+        allow(client).to receive(:download).and_call_original
+      end
+
+      it 'does not download the file again' do
+        expect do
+          client.fetch_warcs(
+            collection: collection_id,
+            crawl_start_after: crawl_start_after,
+            crawl_start_before: crawl_start_before,
+            output_dir: output_dir
+          )
+        end.not_to raise_error
+        expect(client).not_to have_received(:download)
+      end
+    end
+
+    context 'when file does not have valid checksum' do
       before do
         allow(Digest::MD5).to receive(:file).and_return(instance_double(Digest::MD5, hexdigest: 'invalid checksum'))
       end

--- a/wasapi_client.gemspec
+++ b/wasapi_client.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'digest'
   spec.add_dependency 'faraday'
   spec.add_dependency 'faraday-follow_redirects'
   spec.add_dependency 'faraday-retry'


### PR DESCRIPTION
Adds the following features:
* Skips download of WARCs that are already downloaded and whose checksums match what is provided in the API response. 
* Checks downloaded files' checksums to verify completely downloaded. This is the default, built-in behavior rather than configurable. 

Also fixes pagination of results. 